### PR TITLE
Return an object as the root node

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,7 +49,10 @@ async def read_item(barcode: int, format: Optional[str] = "xml"):
         return folio_inventory.json()
     else:
         data = readfromstring(folio_inventory.text)
-        xml = json2xml.Json2xml(data).to_xml()
+        # FOLIO /inventory/items endpoint always returns list
+        # -- trim to single item because SpineOMatic expects object as root node
+        item = data["items"][0]
+        xml = json2xml.Json2xml(item, wrapper="item").to_xml()
         return Response(content=xml, media_type="application/xml")
 
 


### PR DESCRIPTION
It appears that SpineOMatic is expecting an object at the root node.
Since FOLIO's `/inventory/items` endpoint always returns a list [1],
we need to trim it down to the item itself before returning a
tailored response suitable for consumption by SpineOMatic.

Making use of `xml2json` custom wrapper [2] to set the root node.

[1]: https://s3.amazonaws.com/foliodocs/api/mod-inventory/inventory.html#inventory_items_get
[2]: https://json2xml.readthedocs.io/en/latest/#custom-wrappers-and-indent

> As originally discovered while testing [#2](https://github.com/cul-it/setae-api/pull/2#issuecomment-780824051)