### PR TITLE
Actions: Amazon ECS deployment

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -48,6 +48,16 @@ jobs:
         env:
           executionRoleArn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_NUMBER }}:role/folio-contrib-dev_setae-api_ecs_task_execution_role
 
+      - name: Fill in the environment variables in the Amazon ECS task definition
+        id: task-def-env-vars
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: "task-definition.json"
+        env:
+          containerDefinitions.0.environment.0.value: ${{ secrets.OKAPI_TENANT }}
+          containerDefinitions.0.environment.1.value: ${{ secrets.OKAPI_TOKEN }}
+          containerDefinitions.0.environment.2.value: ${{ secrets.OKAPI_URL }}
+
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1

--- a/task-definition.json
+++ b/task-definition.json
@@ -25,7 +25,20 @@
       "command": null,
       "linuxParameters": null,
       "cpu": 256,
-      "environment": [],
+      "environment": [
+        {
+          "name": "OKAPI_TENANT",
+          "value": ""
+        },
+        {
+          "name": "OKAPI_TOKEN",
+          "value": ""
+        },
+        {
+          "name": "OKAPI_URL",
+          "value": ""
+        }
+      ],
       "resourceRequirements": null,
       "ulimits": null,
       "dnsServers": null,


### PR DESCRIPTION
On any successful merge to `main`, this workflow will:
* build and push a new container image to Amazon ECR
* deploy a new task definition to Amazon ECS

> P.S. Keeping the temp switch to trigger on this branch only (8e60fe8) for a bit longer to avoid unnecessary deploys until we have the actions in play on #4