### PR TITLE
Catch & return error message when no item found

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,7 +100,7 @@ async def read_item(
             else:
                 xml = xml_raw
 
-        except IndexError as e:
+        except IndexError:
             xml = etree.tostring(
                 E.error(E.message(f"No item found for barcode {barcode}"))
             )


### PR DESCRIPTION
Return a human readable error message (as XML) that no item was found for the barcode submitted.